### PR TITLE
chore: add eslint and prettier config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "prettier"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "git.autofetch": true
+  "git.autofetch": true
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.json . --ext .js,.jsx,.ts,.tsx",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "browser-image-compression": "^2.0.2",
@@ -24,6 +26,10 @@
     "next-pwa": "^5.6.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.12",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "eslint": "^9.32.0",
+    "eslint-config-next": "^14.2.3",
+    "prettier": "^3.6.2",
+    "eslint-config-prettier": "^9.1.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 ﻿module.exports = {
   plugins: {
-    "@tailwindcss/postcss": {},
+    '@tailwindcss/postcss': {},
   },
 };

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -8,8 +8,18 @@
   "theme_color": "#0b5ed7",
   "background_color": "#111827",
   "icons": [
-    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
-    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
   ],
   "shortcuts": [
     { "name": "Unos aktivnosti", "short_name": "Unos", "url": "/unos" },

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,34 +1,85 @@
 <!doctype html>
 <html lang="bs">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Offline</title>
-  <style>
-    :root { color-scheme: dark; }
-    body{margin:0;font:16px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:#0b0f19;color:#e5e7eb;display:grid;min-height:100vh;place-items:center}
-    .card{max-width:560px;padding:24px;border:1px solid #1f2937;border-radius:16px;background:rgba(255,255,255,.04);backdrop-filter:blur(6px)}
-    h1{margin:0 0 8px;font-size:22px}
-    p{margin:0 0 12px;color:#cbd5e1}
-    ul{margin:8px 0 0;padding-left:18px}
-    a{color:#93c5fd;text-decoration:none}
-    a:hover{text-decoration:underline}
-    .btn{display:inline-block;margin-top:12px;padding:10px 14px;border-radius:10px;background:#2563eb;color:#fff;text-decoration:none}
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Nisi povezan na internet</h1>
-    <p>Aplikacija je u offline režimu. Kad se veza vrati, stranice će se automatski osvježiti.</p>
-    <p>Probaj otvoriti već keširane stranice:</p>
-    <ul>
-      <li><a href="/">Početna</a></li>
-      <li><a href="/unos">Unos</a></li>
-      <li><a href="/pregled">Pregled</a></li>
-      <li><a href="/izvjestaj">Izvještaj</a></li>
-      <li><a href="/period">Periodični</a></li>
-    </ul>
-    <a class="btn" href="" onclick="location.reload();return false;">Pokušaj ponovo</a>
-  </div>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Offline</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        font:
+          16px/1.4 system-ui,
+          -apple-system,
+          Segoe UI,
+          Roboto,
+          Helvetica,
+          Arial,
+          sans-serif;
+        background: #0b0f19;
+        color: #e5e7eb;
+        display: grid;
+        min-height: 100vh;
+        place-items: center;
+      }
+      .card {
+        max-width: 560px;
+        padding: 24px;
+        border: 1px solid #1f2937;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.04);
+        backdrop-filter: blur(6px);
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 22px;
+      }
+      p {
+        margin: 0 0 12px;
+        color: #cbd5e1;
+      }
+      ul {
+        margin: 8px 0 0;
+        padding-left: 18px;
+      }
+      a {
+        color: #93c5fd;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .btn {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 10px 14px;
+        border-radius: 10px;
+        background: #2563eb;
+        color: #fff;
+        text-decoration: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Nisi povezan na internet</h1>
+      <p>
+        Aplikacija je u offline režimu. Kad se veza vrati, stranice će se
+        automatski osvježiti.
+      </p>
+      <p>Probaj otvoriti već keširane stranice:</p>
+      <ul>
+        <li><a href="/">Početna</a></li>
+        <li><a href="/unos">Unos</a></li>
+        <li><a href="/pregled">Pregled</a></li>
+        <li><a href="/izvjestaj">Izvještaj</a></li>
+        <li><a href="/period">Periodični</a></li>
+      </ul>
+      <a class="btn" href="" onclick="location.reload();return false;"
+        >Pokušaj ponovo</a
+      >
+    </div>
+  </body>
 </html>

--- a/src/app/(tabs)/izvjestaj/page.tsx
+++ b/src/app/(tabs)/izvjestaj/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useMemo, useState } from "react";
-import { db } from "@/lib/db";
-import { exportActivitiesToExcel } from "@/lib/excel";
-import type { ActivityItem } from "@/lib/types";
+import { useMemo, useState } from 'react';
+import { db } from '@/lib/db';
+import { exportActivitiesToExcel } from '@/lib/excel';
+import type { ActivityItem } from '@/lib/types';
 
 export default function IzvjestajPage() {
   const today = new Date().toISOString().slice(0, 10);
@@ -19,14 +19,20 @@ export default function IzvjestajPage() {
   async function fetchByDay(d: string): Promise<ActivityItem[]> {
     const lo = d;
     const hi = d + '\uffff';
-    return db.activities.where('datum').between(lo, hi, true, true).sortBy('datum');
+    return db.activities
+      .where('datum')
+      .between(lo, hi, true, true)
+      .sortBy('datum');
   }
 
   async function fetchByPeriod(a: string, b: string): Promise<ActivityItem[]> {
     const [fromD, toD] = a <= b ? [a, b] : [b, a];
     const lo = fromD;
     const hi = toD + '\uffff'; // uključi cijeli dan "toD"
-    return db.activities.where('datum').between(lo, hi, true, true).sortBy('datum');
+    return db.activities
+      .where('datum')
+      .between(lo, hi, true, true)
+      .sortBy('datum');
   }
 
   const periodLabel = useMemo(() => {
@@ -42,7 +48,7 @@ export default function IzvjestajPage() {
     }
     if (mode === 'period') {
       if (!from) return alert('Unesi datum "Od".');
-      if (!to)   return alert('Unesi datum "Do".');
+      if (!to) return alert('Unesi datum "Do".');
     }
 
     setBusy(true);
@@ -63,7 +69,7 @@ export default function IzvjestajPage() {
 
       await exportActivitiesToExcel(
         rows,
-        mode === 'day' ? { kind: 'day', day } : { kind: 'period', from, to }
+        mode === 'day' ? { kind: 'day', day } : { kind: 'period', from, to },
       );
     } catch (err) {
       console.error(err);
@@ -142,12 +148,15 @@ export default function IzvjestajPage() {
           {busy ? 'Pripremam Excel…' : 'Napravi Excel (.xlsx)'}
         </button>
         <span className="text-sm opacity-80">
-          {count === null ? `Odabir: ${periodLabel}` : `Zapisa: ${count} — ${periodLabel}`}
+          {count === null
+            ? `Odabir: ${periodLabel}`
+            : `Zapisa: ${count} — ${periodLabel}`}
         </span>
       </div>
 
       <p className="text-xs opacity-70">
-        Excel fajl sadrži sve kolone + <b>ugrađene fotografije</b> (ne linkove). Naziv se generiše automatski.
+        Excel fajl sadrži sve kolone + <b>ugrađene fotografije</b> (ne linkove).
+        Naziv se generiše automatski.
       </p>
     </div>
   );

--- a/src/app/(tabs)/period/page.tsx
+++ b/src/app/(tabs)/period/page.tsx
@@ -6,7 +6,10 @@ import type { ActivityItem } from '@/lib/types';
 
 // ---------- helpers ----------
 const today = new Date().toISOString().slice(0, 10);
-const fmtDMY = (iso: string) => { const [y,m,d]=iso.split('-'); return `${d}.${m}.${y}`; };
+const fmtDMY = (iso: string) => {
+  const [y, m, d] = iso.split('-');
+  return `${d}.${m}.${y}`;
+};
 const betweenLex = (a: string, b: string) => {
   const [from, to] = a <= b ? [a, b] : [b, a];
   return db.activities.where('datum').between(from, to + '\uffff', true, true);
@@ -15,38 +18,65 @@ const betweenLex = (a: string, b: string) => {
 // robustno dohvaćanje dataURL-a fotke
 async function photoToDataURL(p: any): Promise<string | null> {
   try {
-    if (typeof p?.data === 'string' && p.data.startsWith('data:image/')) return p.data;
-    if (typeof p?.base64 === 'string') return p.base64.startsWith('data:') ? p.base64 : `data:image/jpeg;base64,${p.base64}`;
+    if (typeof p?.data === 'string' && p.data.startsWith('data:image/'))
+      return p.data;
+    if (typeof p?.base64 === 'string')
+      return p.base64.startsWith('data:')
+        ? p.base64
+        : `data:image/jpeg;base64,${p.base64}`;
     if (p?.blob instanceof Blob) {
       const r = new FileReader();
-      const prom = new Promise<string>((res, rej)=>{ r.onload=()=>res(r.result as string); r.onerror=rej; });
-      r.readAsDataURL(p.blob); return await prom;
+      const prom = new Promise<string>((res, rej) => {
+        r.onload = () => res(r.result as string);
+        r.onerror = rej;
+      });
+      r.readAsDataURL(p.blob);
+      return await prom;
     }
     const src: string | undefined = p?.blobUrl || p?.url;
     if (src) {
       const b = await (await fetch(src)).blob();
       const r = new FileReader();
-      const prom = new Promise<string>((res, rej)=>{ r.onload=()=>res(r.result as string); r.onerror=rej; });
-      r.readAsDataURL(b); return await prom;
+      const prom = new Promise<string>((res, rej) => {
+        r.onload = () => res(r.result as string);
+        r.onerror = rej;
+      });
+      r.readAsDataURL(b);
+      return await prom;
     }
     return null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
-type Metrics = { visits: number; offers: number; closed: number; competition: number; photos: number; crm: number; };
+type Metrics = {
+  visits: number;
+  offers: number;
+  closed: number;
+  competition: number;
+  photos: number;
+  crm: number;
+};
 
 function calcMetrics(rows: ActivityItem[]): Metrics {
-  let visits=0, offers=0, closed=0, competition=0, photos=0, crm=0;
+  let visits = 0,
+    offers = 0,
+    closed = 0,
+    competition = 0,
+    photos = 0,
+    crm = 0;
   const offerRe = /\bponud/i;
   const closedRe = /\bnarudž|narudz|zatvoren/i;
   for (const r of rows as any[]) {
     const vrst = (r.vrstaKontakta || '').toLowerCase();
     if (vrst.includes('fiz') || vrst.includes('posjet')) visits++;
-    const text = `${r.tema ?? ''} ${r.napomena ?? ''} ${r.zakljucak ?? ''}`.toLowerCase();
+    const text =
+      `${r.tema ?? ''} ${r.napomena ?? ''} ${r.zakljucak ?? ''}`.toLowerCase();
     if (offerRe.test(text)) offers++;
     if (closedRe.test(text)) closed++;
     if (r.konkurencija && String(r.konkurencija).trim()) competition++;
-    photos += (r.fotografije?.length ?? 0);
+    photos += r.fotografije?.length ?? 0;
     if (r.crmAzuriran) crm++;
   }
   return { visits, offers, closed, competition, photos, crm };
@@ -57,13 +87,15 @@ async function buildReportHTML(
   rows: ActivityItem[],
   period: { from: string; to: string },
   notes: { komentar: string; prijedlozi: string; problemi: string },
-  overrides: { offers?: number; closed?: number } = {}
+  overrides: { offers?: number; closed?: number } = {},
 ): Promise<string> {
   const auto = calcMetrics(rows);
   const m: Metrics = {
     ...auto,
-    offers: typeof overrides.offers === 'number' ? overrides.offers : auto.offers,
-    closed: typeof overrides.closed === 'number' ? overrides.closed : auto.closed,
+    offers:
+      typeof overrides.offers === 'number' ? overrides.offers : auto.offers,
+    closed:
+      typeof overrides.closed === 'number' ? overrides.closed : auto.closed,
   };
 
   const ROW_THUMBS = 5;
@@ -87,7 +119,7 @@ async function buildReportHTML(
   }
 
   const genAt = new Date();
-  const genText = `${String(genAt.getDate()).padStart(2,'0')}. ${String(genAt.getMonth()+1).padStart(2,'0')}. ${genAt.getFullYear()}. ${String(genAt.getHours()).padStart(2,'0')}:${String(genAt.getMinutes()).padStart(2,'0')}:${String(genAt.getSeconds()).padStart(2,'0')}`;
+  const genText = `${String(genAt.getDate()).padStart(2, '0')}. ${String(genAt.getMonth() + 1).padStart(2, '0')}. ${genAt.getFullYear()}. ${String(genAt.getHours()).padStart(2, '0')}:${String(genAt.getMinutes()).padStart(2, '0')}:${String(genAt.getSeconds()).padStart(2, '0')}`;
 
   return `<!doctype html><html lang="bs"><head><meta charset="utf-8"/>
   <title>KPI Izvještaj za period - ${period.from} do ${period.to}</title>
@@ -123,8 +155,8 @@ async function buildReportHTML(
   <div class="period">Period: ${period.from} - ${period.to}</div>
   <section class="cards">
     <div class="card"><h3>Fizički posjeti kupcima</h3><div class="val">${m.visits}</div><div class="meta">Automatski</div></div>
-    <div class="card"><h3>Poslane ponude</h3><div class="val">${m.offers}</div><div class="meta">${typeof overrides.offers==='number'?'Ručno':'Automatski'}</div></div>
-    <div class="card"><h3>Zatvorene narudžbe</h3><div class="val">${m.closed}</div><div class="meta">${typeof overrides.closed==='number'?'Ručno':'Automatski'}</div></div>
+    <div class="card"><h3>Poslane ponude</h3><div class="val">${m.offers}</div><div class="meta">${typeof overrides.offers === 'number' ? 'Ručno' : 'Automatski'}</div></div>
+    <div class="card"><h3>Zatvorene narudžbe</h3><div class="val">${m.closed}</div><div class="meta">${typeof overrides.closed === 'number' ? 'Ručno' : 'Automatski'}</div></div>
     <div class="card"><h3>Izvještaji o konkurenciji</h3><div class="val">${m.competition}</div><div class="meta">Automatski</div></div>
     <div class="card"><h3>Fotografije s terena</h3><div class="val">${m.photos}</div><div class="meta">Automatski</div></div>
     <div class="card"><h3>CRM ažurirano</h3><div class="val">${m.crm}</div><div class="meta">Automatski</div></div>
@@ -134,9 +166,9 @@ async function buildReportHTML(
     <th>Datum</th><th>Kupac</th><th>Vrsta kontakta</th><th>Tema</th><th>CRM</th><th>Slike</th>
   </tr></thead><tbody>${trs.join('')}</tbody></table>
   <section class="grid3">
-    <div class="panel"><h4>Komentar</h4><div>${(notes.komentar||'').replace(/\n/g,'<br/>')}</div></div>
-    <div class="panel"><h4>Prijedlozi</h4><div>${(notes.prijedlozi||'').replace(/\n/g,'<br/>')}</div></div>
-    <div class="panel"><h4>Problemi</h4><div>${(notes.problemi||'').replace(/\n/g,'<br/>')}</div></div>
+    <div class="panel"><h4>Komentar</h4><div>${(notes.komentar || '').replace(/\n/g, '<br/>')}</div></div>
+    <div class="panel"><h4>Prijedlozi</h4><div>${(notes.prijedlozi || '').replace(/\n/g, '<br/>')}</div></div>
+    <div class="panel"><h4>Problemi</h4><div>${(notes.problemi || '').replace(/\n/g, '<br/>')}</div></div>
   </section>
   <footer>Generisano: ${fmtDMY(period.to)} • ${genText}</footer>
   </body></html>`;
@@ -145,12 +177,21 @@ async function buildReportHTML(
 function downloadHtml(name: string, html: string) {
   const blob = new Blob([html], { type: 'text/html;charset=utf-8' });
   const url = URL.createObjectURL(blob);
-  const a = document.createElement('a'); a.href = url; a.download = name;
-  document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
 }
 function openPrint(html: string) {
-  const w = window.open('', '_blank'); if (!w) return;
-  w.document.open(); w.document.write(html); w.document.close(); w.focus();
+  const w = window.open('', '_blank');
+  if (!w) return;
+  w.document.open();
+  w.document.write(html);
+  w.document.close();
+  w.focus();
 }
 
 // ---------- Page ----------
@@ -165,11 +206,18 @@ export default function PeriodicReportPage() {
   const [problemi, setProblemi] = useState('');
 
   // live metrike (auto)
-  const [autoM, setAutoM] = useState<Metrics>({ visits:0, offers:0, closed:0, competition:0, photos:0, crm:0 });
+  const [autoM, setAutoM] = useState<Metrics>({
+    visits: 0,
+    offers: 0,
+    closed: 0,
+    competition: 0,
+    photos: 0,
+    crm: 0,
+  });
 
   // ručni unos za ponude/narudžbe
-  const [offersMode, setOffersMode] = useState<'auto'|'manual'>('auto');
-  const [closedMode, setClosedMode] = useState<'auto'|'manual'>('auto');
+  const [offersMode, setOffersMode] = useState<'auto' | 'manual'>('auto');
+  const [closedMode, setClosedMode] = useState<'auto' | 'manual'>('auto');
   const [offersManual, setOffersManual] = useState<number>(0);
   const [closedManual, setClosedManual] = useState<number>(0);
 
@@ -185,7 +233,10 @@ export default function PeriodicReportPage() {
   const shownOffers = offersMode === 'manual' ? offersManual : autoM.offers;
   const shownClosed = closedMode === 'manual' ? closedManual : autoM.closed;
 
-  const periodLabel = useMemo(() => `${fmtDMY(from)} – ${fmtDMY(to)}`, [from, to]);
+  const periodLabel = useMemo(
+    () => `${fmtDMY(from)} – ${fmtDMY(to)}`,
+    [from, to],
+  );
 
   async function getRows(): Promise<ActivityItem[]> {
     return betweenLex(from, to).sortBy('datum');
@@ -202,11 +253,13 @@ export default function PeriodicReportPage() {
         {
           offers: offersMode === 'manual' ? offersManual : undefined,
           closed: closedMode === 'manual' ? closedManual : undefined,
-        }
+        },
       );
       const name = `KPI_izvještaj_za_period_od_${from}_do_${to}.html`;
       downloadHtml(name, html);
-    } finally { setBusy(false); }
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function handlePrint() {
@@ -220,198 +273,281 @@ export default function PeriodicReportPage() {
         {
           offers: offersMode === 'manual' ? offersManual : undefined,
           closed: closedMode === 'manual' ? closedManual : undefined,
-        }
+        },
       );
       openPrint(html);
-    } finally { setBusy(false); }
+    } finally {
+      setBusy(false);
+    }
   }
 
   // WORD export (DOCX) – izgled kao na print/HTML-u
-async function handleExportWord() {
-  setBusy(true);
-  try {
-    const rows = await getRows();
-    const {
-      Document, Packer, Paragraph, HeadingLevel, TextRun,
-      Table, TableRow, TableCell, WidthType, AlignmentType,
-      BorderStyle, VerticalAlign, ShadingType
-    } = await import('docx');
+  async function handleExportWord() {
+    setBusy(true);
+    try {
+      const rows = await getRows();
+      const {
+        Document,
+        Packer,
+        Paragraph,
+        HeadingLevel,
+        TextRun,
+        Table,
+        TableRow,
+        TableCell,
+        WidthType,
+        AlignmentType,
+        BorderStyle,
+        VerticalAlign,
+        ShadingType,
+      } = await import('docx');
 
-    // Auto metrike + ručni override
-    const auto = calcMetrics(rows);
-    const M = {
-      ...auto,
-      offers: shownOffers,
-      closed: shownClosed,
-    };
+      // Auto metrike + ručni override
+      const auto = calcMetrics(rows);
+      const M = {
+        ...auto,
+        offers: shownOffers,
+        closed: shownClosed,
+      };
 
-    // ---------- Header ----------
-    const title = new Paragraph({
-      text: 'KPI Izvještaj',
-      heading: HeadingLevel.TITLE,
-      alignment: AlignmentType.CENTER,
-    });
-    const periodP = new Paragraph({
-      children: [new TextRun({ text: `Period: ${from} - ${to}`, size: 28 })],
-      alignment: AlignmentType.CENTER,
-      spacing: { after: 200 },
-    });
+      // ---------- Header ----------
+      const title = new Paragraph({
+        text: 'KPI Izvještaj',
+        heading: HeadingLevel.TITLE,
+        alignment: AlignmentType.CENTER,
+      });
+      const periodP = new Paragraph({
+        children: [new TextRun({ text: `Period: ${from} - ${to}`, size: 28 })],
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 200 },
+      });
 
-    // ---------- Metric "card" cell ----------
-    const metricCell = (label: string, value: number, meta: 'Automatski' | 'Ručno') =>
-      new TableCell({
-        verticalAlign: VerticalAlign.CENTER,
-        margins: { top: 200, bottom: 200, left: 200, right: 200 },
-        shading: { type: ShadingType.CLEAR, fill: 'F9FAFB' }, // svijetla pozadina
-        children: [
-          new Paragraph({
-            alignment: AlignmentType.CENTER,
-            spacing: { after: 80 },
-            children: [new TextRun({ text: String(value), bold: true, color: '0B5ED7', size: 56 })], // veliki broj
+      // ---------- Metric "card" cell ----------
+      const metricCell = (
+        label: string,
+        value: number,
+        meta: 'Automatski' | 'Ručno',
+      ) =>
+        new TableCell({
+          verticalAlign: VerticalAlign.CENTER,
+          margins: { top: 200, bottom: 200, left: 200, right: 200 },
+          shading: { type: ShadingType.CLEAR, fill: 'F9FAFB' }, // svijetla pozadina
+          children: [
+            new Paragraph({
+              alignment: AlignmentType.CENTER,
+              spacing: { after: 80 },
+              children: [
+                new TextRun({
+                  text: String(value),
+                  bold: true,
+                  color: '0B5ED7',
+                  size: 56,
+                }),
+              ], // veliki broj
+            }),
+            new Paragraph({
+              alignment: AlignmentType.CENTER,
+              spacing: { after: 40 },
+              children: [
+                new TextRun({ text: label, color: '374151', size: 24 }),
+              ],
+            }),
+            new Paragraph({
+              alignment: AlignmentType.CENTER,
+              children: [
+                new TextRun({ text: meta, color: '059669', size: 18 }),
+              ],
+            }),
+          ],
+        });
+
+      // 2 reda × 3 kolone metrika
+      const metricsTable = new Table({
+        width: { size: 100, type: WidthType.PERCENTAGE },
+        rows: [
+          new TableRow({
+            children: [
+              metricCell('Fizički posjeti kupcima', M.visits, 'Automatski'),
+              metricCell(
+                'Poslane ponude',
+                M.offers,
+                offersMode === 'manual' ? 'Ručno' : 'Automatski',
+              ),
+              metricCell(
+                'Zatvorene narudžbe',
+                M.closed,
+                closedMode === 'manual' ? 'Ručno' : 'Automatski',
+              ),
+            ],
           }),
-          new Paragraph({
-            alignment: AlignmentType.CENTER,
-            spacing: { after: 40 },
-            children: [new TextRun({ text: label, color: '374151', size: 24 })],
-          }),
-          new Paragraph({
-            alignment: AlignmentType.CENTER,
-            children: [new TextRun({ text: meta, color: '059669', size: 18 })],
+          new TableRow({
+            children: [
+              metricCell(
+                'Izvještaji o konkurenciji',
+                M.competition,
+                'Automatski',
+              ),
+              metricCell('Fotografije s terena', M.photos, 'Automatski'),
+              metricCell('CRM ažurirano', M.crm, 'Automatski'),
+            ],
           }),
         ],
       });
 
-    // 2 reda × 3 kolone metrika
-    const metricsTable = new Table({
-      width: { size: 100, type: WidthType.PERCENTAGE },
-      rows: [
-        new TableRow({
-          children: [
-            metricCell('Fizički posjeti kupcima', M.visits, 'Automatski'),
-            metricCell('Poslane ponude', M.offers, offersMode === 'manual' ? 'Ručno' : 'Automatski'),
-            metricCell('Zatvorene narudžbe', M.closed, closedMode === 'manual' ? 'Ručno' : 'Automatski'),
-          ],
-        }),
-        new TableRow({
-          children: [
-            metricCell('Izvještaji o konkurenciji', M.competition, 'Automatski'),
-            metricCell('Fotografije s terena', M.photos, 'Automatski'),
-            metricCell('CRM ažurirano', M.crm, 'Automatski'),
-          ],
-        }),
-      ],
-    });
-
-    // ---------- Sekcijski naslov + plava linija ----------
-    const sectionTitle = new Paragraph({
-      children: [new TextRun({ text: 'Detaljni pregled aktivnosti', bold: true, size: 26 })],
-      spacing: { before: 300, after: 80 },
-    });
-    const blueRule = new Paragraph({
-      children: [new TextRun(' ')],
-      border: {
-        bottom: { color: '0B5ED7', size: 6, space: 1, style: BorderStyle.SINGLE },
-      },
-      spacing: { after: 120 },
-    });
-
-    // ---------- Tabela aktivnosti (header stil kao na slici) ----------
-    const headerCell = (text: string) =>
-      new TableCell({
-        verticalAlign: VerticalAlign.CENTER,
-        shading: { type: ShadingType.CLEAR, fill: 'F3F4F6' },
-        borders: {
-          top: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
-          bottom: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
-          left: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
-          right: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
+      // ---------- Sekcijski naslov + plava linija ----------
+      const sectionTitle = new Paragraph({
+        children: [
+          new TextRun({
+            text: 'Detaljni pregled aktivnosti',
+            bold: true,
+            size: 26,
+          }),
+        ],
+        spacing: { before: 300, after: 80 },
+      });
+      const blueRule = new Paragraph({
+        children: [new TextRun(' ')],
+        border: {
+          bottom: {
+            color: '0B5ED7',
+            size: 6,
+            space: 1,
+            style: BorderStyle.SINGLE,
+          },
         },
+        spacing: { after: 120 },
+      });
+
+      // ---------- Tabela aktivnosti (header stil kao na slici) ----------
+      const headerCell = (text: string) =>
+        new TableCell({
+          verticalAlign: VerticalAlign.CENTER,
+          shading: { type: ShadingType.CLEAR, fill: 'F3F4F6' },
+          borders: {
+            top: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
+            bottom: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
+            left: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
+            right: { style: BorderStyle.SINGLE, size: 6, color: 'E5E7EB' },
+          },
+          children: [
+            new Paragraph({
+              children: [new TextRun({ text, bold: true })],
+            }),
+          ],
+        });
+
+      const bodyCell = (text: string, opts: { center?: boolean } = {}) =>
+        new TableCell({
+          children: [
+            new Paragraph({
+              alignment: opts.center
+                ? AlignmentType.CENTER
+                : AlignmentType.LEFT,
+              children: [new TextRun(String(text ?? ''))],
+            }),
+          ],
+        });
+
+      const headerRow = new TableRow({
         children: [
-          new Paragraph({
-            children: [new TextRun({ text, bold: true })],
+          'Datum',
+          'Kupac',
+          'Vrsta kontakta',
+          'Tema',
+          'CRM',
+          'Slike',
+        ].map(headerCell),
+      });
+
+      const dataRows = rows.map(
+        (r: any) =>
+          new TableRow({
+            children: [
+              bodyCell(r.datum ?? ''),
+              bodyCell(r.kupac ?? ''),
+              bodyCell(r.vrstaKontakta ?? ''),
+              bodyCell(r.tema ?? ''),
+              bodyCell(r.crmAzuriran ? 'DA' : 'NE', { center: true }),
+              bodyCell(String(r.fotografije?.length ?? 0), { center: true }), // broj slika (thumbnail-e možemo dodati po želji)
+            ],
           }),
+      );
+
+      const tableAct = new Table({
+        width: { size: 100, type: WidthType.PERCENTAGE },
+        rows: [headerRow, ...dataRows],
+      });
+
+      // ---------- Footer ----------
+      const now = new Date();
+      const gen =
+        `${String(now.getDate()).padStart(2, '0')}. ${String(now.getMonth() + 1).padStart(2, '0')}. ${now.getFullYear()}. ` +
+        `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
+      const footer = new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { before: 200 },
+        children: [
+          new TextRun({ text: `Generisano: ${gen}`, color: '6B7280' }),
         ],
       });
 
-    const bodyCell = (text: string, opts: { center?: boolean } = {}) =>
-      new TableCell({
-        children: [
-          new Paragraph({
-            alignment: opts.center ? AlignmentType.CENTER : AlignmentType.LEFT,
-            children: [new TextRun(String(text ?? ''))],
-          }),
+      // ---------- Dokument ----------
+      const doc = new Document({
+        sections: [
+          {
+            children: [
+              title,
+              periodP,
+              metricsTable,
+              sectionTitle,
+              blueRule,
+              tableAct,
+              footer,
+            ],
+          },
         ],
       });
 
-    const headerRow = new TableRow({
-      children: ['Datum','Kupac','Vrsta kontakta','Tema','CRM','Slike'].map(headerCell),
-    });
-
-    const dataRows = rows.map((r: any) =>
-      new TableRow({
-        children: [
-          bodyCell(r.datum ?? ''),
-          bodyCell(r.kupac ?? ''),
-          bodyCell(r.vrstaKontakta ?? ''),
-          bodyCell(r.tema ?? ''),
-          bodyCell(r.crmAzuriran ? 'DA' : 'NE', { center: true }),
-          bodyCell(String(r.fotografije?.length ?? 0), { center: true }), // broj slika (thumbnail-e možemo dodati po želji)
-        ],
-      })
-    );
-
-    const tableAct = new Table({
-      width: { size: 100, type: WidthType.PERCENTAGE },
-      rows: [headerRow, ...dataRows],
-    });
-
-    // ---------- Footer ----------
-    const now = new Date();
-    const gen = `${String(now.getDate()).padStart(2,'0')}. ${String(now.getMonth()+1).padStart(2,'0')}. ${now.getFullYear()}. ` +
-                `${String(now.getHours()).padStart(2,'0')}:${String(now.getMinutes()).padStart(2,'0')}:${String(now.getSeconds()).padStart(2,'0')}`;
-    const footer = new Paragraph({
-      alignment: AlignmentType.CENTER,
-      spacing: { before: 200 },
-      children: [new TextRun({ text: `Generisano: ${gen}`, color: '6B7280' })],
-    });
-
-    // ---------- Dokument ----------
-    const doc = new Document({
-      sections: [
-        { children: [title, periodP, metricsTable, sectionTitle, blueRule, tableAct, footer] },
-      ],
-    });
-
-    const blob = await Packer.toBlob(doc);
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url; a.download = `KPI_Izvještaj_za_period_od${from}_do_${to}.docx`; a.click();
-    URL.revokeObjectURL(url);
-  } catch (e) {
-    console.error(e);
-    alert('Greška pri Word exportu. Provjeri da je paket "docx" instaliran.');
-  } finally {
-    setBusy(false);
+      const blob = await Packer.toBlob(doc);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `KPI_Izvještaj_za_period_od${from}_do_${to}.docx`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      console.error(e);
+      alert('Greška pri Word exportu. Provjeri da je paket "docx" instaliran.');
+    } finally {
+      setBusy(false);
+    }
   }
-}
-
-
 
   return (
     <div className="max-w-5xl mx-auto p-4 space-y-4">
       <div className="border border-white/10 bg-white/5 rounded-2xl p-4 space-y-3">
-        <div className="text-lg font-semibold text-white">📊 Periodični izvještaj</div>
+        <div className="text-lg font-semibold text-white">
+          📊 Periodični izvještaj
+        </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div className="flex flex-col">
             <label className="text-sm text-white/80 mb-1">Od datuma</label>
-            <input type="date" value={from} onChange={e=>setFrom(e.target.value)}
-              className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white" />
+            <input
+              type="date"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+              className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white"
+            />
           </div>
           <div className="flex flex-col">
             <label className="text-sm text-white/80 mb-1">Do datuma</label>
-            <input type="date" value={to} onChange={e=>setTo(e.target.value)}
-              className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white" />
+            <input
+              type="date"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white"
+            />
           </div>
         </div>
 
@@ -419,20 +555,32 @@ async function handleExportWord() {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           {/* 1 */}
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div className="text-3xl font-bold text-white text-center">{autoM.visits}</div>
-            <div className="text-center text-white/90 mt-1">Fizički posjeti kupcima</div>
-            <div className="text-center text-emerald-400 text-xs mt-1">Automatski</div>
+            <div className="text-3xl font-bold text-white text-center">
+              {autoM.visits}
+            </div>
+            <div className="text-center text-white/90 mt-1">
+              Fizički posjeti kupcima
+            </div>
+            <div className="text-center text-emerald-400 text-xs mt-1">
+              Automatski
+            </div>
           </div>
 
           {/* 2 - Poslane ponude (ručno/auto) */}
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
             <div className="flex items-center justify-center gap-2">
               {offersMode === 'auto' ? (
-                <div className="text-3xl font-bold text-white">{autoM.offers}</div>
+                <div className="text-3xl font-bold text-white">
+                  {autoM.offers}
+                </div>
               ) : (
                 <input
-                  type="number" min={0} value={offersManual}
-                  onChange={e=>setOffersManual(Math.max(0, Number(e.target.value)))}
+                  type="number"
+                  min={0}
+                  value={offersManual}
+                  onChange={(e) =>
+                    setOffersManual(Math.max(0, Number(e.target.value)))
+                  }
                   className="w-24 text-center text-3xl font-bold text-white bg-white/10 border border-white/15 rounded-xl px-2 py-1"
                 />
               )}
@@ -440,13 +588,17 @@ async function handleExportWord() {
             <div className="text-center text-white/90 mt-1">Poslane ponude</div>
             <div className="text-center text-xs mt-1">
               <button
-                className={`px-2 py-0.5 rounded ${offersMode==='auto'?'bg-emerald-600':'bg-white/10'} border border-white/20 text-white mr-1`}
-                onClick={()=>setOffersMode('auto')}
-              >Auto</button>
+                className={`px-2 py-0.5 rounded ${offersMode === 'auto' ? 'bg-emerald-600' : 'bg-white/10'} border border-white/20 text-white mr-1`}
+                onClick={() => setOffersMode('auto')}
+              >
+                Auto
+              </button>
               <button
-                className={`px-2 py-0.5 rounded ${offersMode==='manual'?'bg-emerald-600':'bg-white/10'} border border-white/20 text-white`}
-                onClick={()=>setOffersMode('manual')}
-              >Ručno</button>
+                className={`px-2 py-0.5 rounded ${offersMode === 'manual' ? 'bg-emerald-600' : 'bg-white/10'} border border-white/20 text-white`}
+                onClick={() => setOffersMode('manual')}
+              >
+                Ručno
+              </button>
             </div>
           </div>
 
@@ -454,47 +606,75 @@ async function handleExportWord() {
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
             <div className="flex items-center justify-center gap-2">
               {closedMode === 'auto' ? (
-                <div className="text-3xl font-bold text-white">{autoM.closed}</div>
+                <div className="text-3xl font-bold text-white">
+                  {autoM.closed}
+                </div>
               ) : (
                 <input
-                  type="number" min={0} value={closedManual}
-                  onChange={e=>setClosedManual(Math.max(0, Number(e.target.value)))}
+                  type="number"
+                  min={0}
+                  value={closedManual}
+                  onChange={(e) =>
+                    setClosedManual(Math.max(0, Number(e.target.value)))
+                  }
                   className="w-24 text-center text-3xl font-bold text-white bg-white/10 border border-white/15 rounded-xl px-2 py-1"
                 />
               )}
             </div>
-            <div className="text-center text-white/90 mt-1">Zatvorene narudžbe</div>
+            <div className="text-center text-white/90 mt-1">
+              Zatvorene narudžbe
+            </div>
             <div className="text-center text-xs mt-1">
               <button
-                className={`px-2 py-0.5 rounded ${closedMode==='auto'?'bg-emerald-600':'bg-white/10'} border border-white/20 text-white mr-1`}
-                onClick={()=>setClosedMode('auto')}
-              >Auto</button>
+                className={`px-2 py-0.5 rounded ${closedMode === 'auto' ? 'bg-emerald-600' : 'bg-white/10'} border border-white/20 text-white mr-1`}
+                onClick={() => setClosedMode('auto')}
+              >
+                Auto
+              </button>
               <button
-                className={`px-2 py-0.5 rounded ${closedMode==='manual'?'bg-emerald-600':'bg-white/10'} border border-white/20 text-white`}
-                onClick={()=>setClosedMode('manual')}
-              >Ručno</button>
+                className={`px-2 py-0.5 rounded ${closedMode === 'manual' ? 'bg-emerald-600' : 'bg-white/10'} border border-white/20 text-white`}
+                onClick={() => setClosedMode('manual')}
+              >
+                Ručno
+              </button>
             </div>
           </div>
 
           {/* 4 */}
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div className="text-3xl font-bold text-white text-center">{autoM.competition}</div>
-            <div className="text-center text-white/90 mt-1">Izvještaji o konkurenciji</div>
-            <div className="text-center text-emerald-400 text-xs mt-1">Automatski</div>
+            <div className="text-3xl font-bold text-white text-center">
+              {autoM.competition}
+            </div>
+            <div className="text-center text-white/90 mt-1">
+              Izvještaji o konkurenciji
+            </div>
+            <div className="text-center text-emerald-400 text-xs mt-1">
+              Automatski
+            </div>
           </div>
 
           {/* 5 */}
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div className="text-3xl font-bold text-white text-center">{autoM.photos}</div>
-            <div className="text-center text-white/90 mt-1">Fotografije s terena</div>
-            <div className="text-center text-emerald-400 text-xs mt-1">Automatski</div>
+            <div className="text-3xl font-bold text-white text-center">
+              {autoM.photos}
+            </div>
+            <div className="text-center text-white/90 mt-1">
+              Fotografije s terena
+            </div>
+            <div className="text-center text-emerald-400 text-xs mt-1">
+              Automatski
+            </div>
           </div>
 
           {/* 6 */}
           <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div className="text-3xl font-bold text-white text-center">{autoM.crm}</div>
+            <div className="text-3xl font-bold text-white text-center">
+              {autoM.crm}
+            </div>
             <div className="text-center text-white/90 mt-1">CRM ažuriran</div>
-            <div className="text-center text-emerald-400 text-xs mt-1">Automatski</div>
+            <div className="text-center text-emerald-400 text-xs mt-1">
+              Automatski
+            </div>
           </div>
         </div>
 
@@ -502,18 +682,27 @@ async function handleExportWord() {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
             <div className="text-white/90 mb-2">Komentar</div>
-            <textarea value={komentar} onChange={e=>setKomentar(e.target.value)}
-              className="w-full h-28 px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white" />
+            <textarea
+              value={komentar}
+              onChange={(e) => setKomentar(e.target.value)}
+              className="w-full h-28 px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white"
+            />
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
             <div className="text-white/90 mb-2">Prijedlozi</div>
-            <textarea value={prijedlozi} onChange={e=>setPrijedlozi(e.target.value)}
-              className="w-full h-28 px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white" />
+            <textarea
+              value={prijedlozi}
+              onChange={(e) => setPrijedlozi(e.target.value)}
+              className="w-full h-28 px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white"
+            />
           </div>
           <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
             <div className="text-white/90 mb-2">Problemi</div>
-            <textarea value={problemi} onChange={e=>setProblemi(e.target.value)}
-              className="w-full h-28 px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white" />
+            <textarea
+              value={problemi}
+              onChange={(e) => setProblemi(e.target.value)}
+              className="w-full h-28 px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white"
+            />
           </div>
         </div>
 
@@ -543,7 +732,8 @@ async function handleExportWord() {
             </button>
           </div>
           <div className="text-xs text-white/60">
-            Napomena: HTML export uključuje i slike (thumbnail-e); Word export trenutno prikazuje broj slika po aktivnosti radi veličine dokumenta.
+            Napomena: HTML export uključuje i slike (thumbnail-e); Word export
+            trenutno prikazuje broj slika po aktivnosti radi veličine dokumenta.
           </div>
           <div className="text-white/70 text-sm">Period: {periodLabel}</div>
         </div>

--- a/src/app/(tabs)/pregled/page.tsx
+++ b/src/app/(tabs)/pregled/page.tsx
@@ -31,18 +31,23 @@ function toArrayBuffer(data: ArrayBufferLike | Uint8Array): ArrayBuffer {
 const todayISO = toISODateOnly(new Date());
 
 const KNOWN_KEYS = new Set([
-  'id', 'datum', 'kupac',
-  'vrstaKontakta', 'tema', 'napomena', 'crmAzuriran',
+  'id',
+  'datum',
+  'kupac',
+  'vrstaKontakta',
+  'tema',
+  'napomena',
+  'crmAzuriran',
   'fotografije',
 ]);
 
 type AnyPhoto = {
   id: string;
-  url?: string;           // data: URL ili blob:
-  blob?: Blob;            // binarno
+  url?: string; // data: URL ili blob:
+  blob?: Blob; // binarno
   type?: string;
   data?: ArrayBufferLike | Uint8Array; // legacy bytes
-  base64?: string;        // "data:image/...;base64,..." ili samo čisti base64
+  base64?: string; // "data:image/...;base64,..." ili samo čisti base64
 };
 
 type EditableDraft = {
@@ -128,15 +133,20 @@ export default function Page() {
     (async () => {
       try {
         setLoading(true);
-        const table: any = (db as any).activities ?? (db as any).table?.('activities');
+        const table: any =
+          (db as any).activities ?? (db as any).table?.('activities');
         const all: ActivityItem[] = table ? await table.toArray() : [];
-        const sorted = all.slice().sort((a, b) => (a.datum || '').localeCompare(b.datum || ''));
+        const sorted = all
+          .slice()
+          .sort((a, b) => (a.datum || '').localeCompare(b.datum || ''));
         if (alive) setItems(sorted);
       } finally {
         if (alive) setLoading(false);
       }
     })();
-    return () => { alive = false; };
+    return () => {
+      alive = false;
+    };
   }, []);
 
   // Filter
@@ -153,10 +163,12 @@ export default function Page() {
   }, [items, fromDate, toDate]);
 
   const periodLabel = useMemo(() => {
-    if (fromDate && toDate && fromDate === toDate) return `Danas: ${fmtDMY(fromDate)}`;
-    if (fromDate && toDate) return `Period: ${fmtDMY(fromDate)} – ${fmtDMY(toDate)}`;
+    if (fromDate && toDate && fromDate === toDate)
+      return `Danas: ${fmtDMY(fromDate)}`;
+    if (fromDate && toDate)
+      return `Period: ${fmtDMY(fromDate)} – ${fmtDMY(toDate)}`;
     if (fromDate) return `Od: ${fmtDMY(fromDate)}`;
-    if (toDate)   return `Do: ${fmtDMY(toDate)}`;
+    if (toDate) return `Do: ${fmtDMY(toDate)}`;
     return `Danas: ${fmtDMY(toISODateOnly(new Date()))}`;
   }, [fromDate, toDate]);
 
@@ -181,7 +193,9 @@ export default function Page() {
 
     return () => {
       cancelled = true;
-      urlsToRevoke.forEach((u) => u.startsWith('blob:') && URL.revokeObjectURL(u));
+      urlsToRevoke.forEach(
+        (u) => u.startsWith('blob:') && URL.revokeObjectURL(u),
+      );
     };
   }, [filtered]);
 
@@ -191,7 +205,9 @@ export default function Page() {
     modalUrlsRef.current.forEach((u) => URL.revokeObjectURL(u));
     modalUrlsRef.current = [];
 
-    const rawPhotos = Array.isArray((it as any).fotografije) ? (it as any).fotografije : [];
+    const rawPhotos = Array.isArray((it as any).fotografije)
+      ? (it as any).fotografije
+      : [];
     const normalized: AnyPhoto[] = [];
     for (const p of rawPhotos) {
       const n = await normalizePhoto(p);
@@ -239,16 +255,25 @@ export default function Page() {
       newItems.push({
         id: crypto.randomUUID(),
         blob: compressed,
-        url: b64,             // postavi URL na data: odmah, da je trajno vidljiv
+        url: b64, // postavi URL na data: odmah, da je trajno vidljiv
         base64: b64,
         type: compressed.type,
       });
     }
-    setDraft((d) => (d ? { ...d, fotografije: [...(d.fotografije ?? []), ...newItems] } : d));
+    setDraft((d) =>
+      d ? { ...d, fotografije: [...(d.fotografije ?? []), ...newItems] } : d,
+    );
   }
 
   function removePhoto(id: string) {
-    setDraft((d) => (d ? { ...d, fotografije: (d.fotografije ?? []).filter((p) => p.id !== id) } : d));
+    setDraft((d) =>
+      d
+        ? {
+            ...d,
+            fotografije: (d.fotografije ?? []).filter((p) => p.id !== id),
+          }
+        : d,
+    );
   }
 
   function clearPhotos() {
@@ -257,7 +282,9 @@ export default function Page() {
   }
 
   function updateOther(key: string, value: any) {
-    setDraft((d) => (d ? { ...d, other: { ...(d.other ?? {}), [key]: value } } : d));
+    setDraft((d) =>
+      d ? { ...d, other: { ...(d.other ?? {}), [key]: value } } : d,
+    );
   }
 
   // Snimi (merge)
@@ -265,7 +292,8 @@ export default function Page() {
     if (!draft) return;
     try {
       setSaving(true);
-      const table: any = (db as any).activities ?? (db as any).table?.('activities');
+      const table: any =
+        (db as any).activities ?? (db as any).table?.('activities');
       const original: ActivityItem | undefined = await table.get(draft.id);
       if (!original) throw new Error('Stavka nije pronađena.');
 
@@ -274,11 +302,19 @@ export default function Page() {
         id: draft.id,
         datum: draft.datum,
         kupac: draft.kupac,
-        ...(typeof draft.vrstaKontakta !== 'undefined' ? { vrstaKontakta: draft.vrstaKontakta } : {}),
+        ...(typeof draft.vrstaKontakta !== 'undefined'
+          ? { vrstaKontakta: draft.vrstaKontakta }
+          : {}),
         ...(typeof draft.tema !== 'undefined' ? { tema: draft.tema } : {}),
-        ...(typeof draft.napomena !== 'undefined' ? { napomena: draft.napomena } : {}),
-        ...(typeof draft.crmAzuriran !== 'undefined' ? { crmAzuriran: !!draft.crmAzuriran } : {}),
-        ...(draft.fotografije ? { fotografije: draft.fotografije } as any : {}),
+        ...(typeof draft.napomena !== 'undefined'
+          ? { napomena: draft.napomena }
+          : {}),
+        ...(typeof draft.crmAzuriran !== 'undefined'
+          ? { crmAzuriran: !!draft.crmAzuriran }
+          : {}),
+        ...(draft.fotografije
+          ? ({ fotografije: draft.fotografije } as any)
+          : {}),
         ...(draft.other ?? {}),
       };
 
@@ -304,7 +340,8 @@ export default function Page() {
   async function remove(id: string) {
     if (!confirm('Obrisati stavku?')) return;
     try {
-      const table: any = (db as any).activities ?? (db as any).table?.('activities');
+      const table: any =
+        (db as any).activities ?? (db as any).table?.('activities');
       await table.delete(id);
       setItems((prev) => prev.filter((x) => x.id !== id));
     } catch (e) {
@@ -364,56 +401,59 @@ export default function Page() {
             Nema unosa za izabrani period.
           </div>
         )}
-        {!loading && filtered.map((it) => {
-          const phs = (it as any).fotografije as any[] | undefined;
-          const cnt = phs?.length ?? 0;
-          const thumb = thumbs[it.id];
-          return (
-            <div
-              key={it.id}
-              className="bg-white/5 border border-white/10 rounded-2xl p-3 flex items-center justify-between hover:bg-white/8 transition"
-            >
-              <div className="flex items-center gap-3 min-w-0">
-                {cnt > 0 ? (
-                  <img
-                    src={thumb}
-                    alt=""
-                    className="w-12 h-12 rounded-xl object-cover border border-white/10 shrink-0"
-                  />
-                ) : (
-                  <div className="w-12 h-12 rounded-xl border border-white/10 bg-white/5 grid place-items-center text-xs text-white/50 shrink-0">
-                    —
+        {!loading &&
+          filtered.map((it) => {
+            const phs = (it as any).fotografije as any[] | undefined;
+            const cnt = phs?.length ?? 0;
+            const thumb = thumbs[it.id];
+            return (
+              <div
+                key={it.id}
+                className="bg-white/5 border border-white/10 rounded-2xl p-3 flex items-center justify-between hover:bg-white/8 transition"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  {cnt > 0 ? (
+                    <img
+                      src={thumb}
+                      alt=""
+                      className="w-12 h-12 rounded-xl object-cover border border-white/10 shrink-0"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 rounded-xl border border-white/10 bg-white/5 grid place-items-center text-xs text-white/50 shrink-0">
+                      —
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <div className="text-white font-medium flex items-center gap-2">
+                      {(it as any).kupac || '—'}
+                      {cnt > 0 && (
+                        <span className="text-xs px-2 py-0.5 rounded-full border border-white/15 bg-white/10 text-white/80">
+                          {cnt} sl.
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-white/70 text-sm">
+                      {fmtDMY(toISODateOnly(it.datum))}
+                    </div>
                   </div>
-                )}
-                <div className="min-w-0">
-                  <div className="text-white font-medium flex items-center gap-2">
-                    {(it as any).kupac || '—'}
-                    {cnt > 0 && (
-                      <span className="text-xs px-2 py-0.5 rounded-full border border-white/15 bg-white/10 text-white/80">
-                        {cnt} sl.
-                      </span>
-                    )}
-                  </div>
-                  <div className="text-white/70 text-sm">{fmtDMY(toISODateOnly(it.datum))}</div>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <button
+                    onClick={() => openEdit(it)}
+                    className="px-3 py-1 rounded-xl border border-white/20 bg-white/5 text-white hover:bg-white/10"
+                  >
+                    Uredi
+                  </button>
+                  <button
+                    onClick={() => remove(it.id)}
+                    className="px-3 py-1 rounded-xl border border-white/20 bg-white/5 text-white hover:bg-white/10"
+                  >
+                    Obriši
+                  </button>
                 </div>
               </div>
-              <div className="flex gap-2 shrink-0">
-                <button
-                  onClick={() => openEdit(it)}
-                  className="px-3 py-1 rounded-xl border border-white/20 bg-white/5 text-white hover:bg-white/10"
-                >
-                  Uredi
-                </button>
-                <button
-                  onClick={() => remove(it.id)}
-                  className="px-3 py-1 rounded-xl border border-white/20 bg-white/5 text-white hover:bg-white/10"
-                >
-                  Obriši
-                </button>
-              </div>
-            </div>
-          );
-        })}
+            );
+          })}
       </div>
 
       {/* EDIT MODAL */}
@@ -430,7 +470,14 @@ export default function Page() {
                   type="date"
                   value={toISODateOnly(draft.datum)}
                   onChange={(e) =>
-                    setDraft((d) => (d ? { ...d, datum: new Date(e.target.value).toISOString() } : d))
+                    setDraft((d) =>
+                      d
+                        ? {
+                            ...d,
+                            datum: new Date(e.target.value).toISOString(),
+                          }
+                        : d,
+                    )
                   }
                   className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white focus:outline-none focus:ring-2 focus:ring-white/30"
                 />
@@ -440,21 +487,35 @@ export default function Page() {
                 <input
                   type="text"
                   value={draft.kupac}
-                  onChange={(e) => setDraft((d) => (d ? { ...d, kupac: e.target.value } : d))}
+                  onChange={(e) =>
+                    setDraft((d) => (d ? { ...d, kupac: e.target.value } : d))
+                  }
                   className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-white/30"
                   placeholder="Naziv kupca"
                 />
               </div>
               <div className="flex flex-col">
-                <label className="text-sm text-white/80 mb-1">Vrsta kontakta</label>
+                <label className="text-sm text-white/80 mb-1">
+                  Vrsta kontakta
+                </label>
                 <select
                   value={draft.vrstaKontakta ?? ''}
-                  onChange={(e) => setDraft((d) => (d ? { ...d, vrstaKontakta: e.target.value } : d))}
+                  onChange={(e) =>
+                    setDraft((d) =>
+                      d ? { ...d, vrstaKontakta: e.target.value } : d,
+                    )
+                  }
                   className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white focus:outline-none focus:ring-2 focus:ring-white/30"
                 >
-                  <option value="" disabled>Odaberi...</option>
+                  <option value="" disabled>
+                    Odaberi...
+                  </option>
                   {VRSTE_KONTAKTA.map((opt) => (
-                    <option key={opt.value} value={opt.value} className="bg-neutral-900">
+                    <option
+                      key={opt.value}
+                      value={opt.value}
+                      className="bg-neutral-900"
+                    >
                       {opt.label}
                     </option>
                   ))}
@@ -465,7 +526,9 @@ export default function Page() {
                 <input
                   type="text"
                   value={draft.tema ?? ''}
-                  onChange={(e) => setDraft((d) => (d ? { ...d, tema: e.target.value } : d))}
+                  onChange={(e) =>
+                    setDraft((d) => (d ? { ...d, tema: e.target.value } : d))
+                  }
                   className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-white/30"
                   placeholder="Tema sastanka/kontakta"
                 />
@@ -475,7 +538,11 @@ export default function Page() {
                 <textarea
                   rows={3}
                   value={draft.napomena ?? ''}
-                  onChange={(e) => setDraft((d) => (d ? { ...d, napomena: e.target.value } : d))}
+                  onChange={(e) =>
+                    setDraft((d) =>
+                      d ? { ...d, napomena: e.target.value } : d,
+                    )
+                  }
                   className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-white/30"
                   placeholder="Detalji, dogovoreno, sljedeći koraci…"
                 />
@@ -485,10 +552,16 @@ export default function Page() {
                   id="crm"
                   type="checkbox"
                   checked={!!draft.crmAzuriran}
-                  onChange={(e) => setDraft((d) => (d ? { ...d, crmAzuriran: e.target.checked } : d))}
+                  onChange={(e) =>
+                    setDraft((d) =>
+                      d ? { ...d, crmAzuriran: e.target.checked } : d,
+                    )
+                  }
                   className="h-4 w-4"
                 />
-                <label htmlFor="crm" className="text-sm text-white/90">CRM ažuriran</label>
+                <label htmlFor="crm" className="text-sm text-white/90">
+                  CRM ažuriran
+                </label>
               </div>
             </div>
 
@@ -515,11 +588,15 @@ export default function Page() {
                     if (t === 'number') {
                       return (
                         <div key={key} className="flex flex-col">
-                          <label className="text-sm text-white/80 mb-1">{key}</label>
+                          <label className="text-sm text-white/80 mb-1">
+                            {key}
+                          </label>
                           <input
                             type="number"
                             value={val}
-                            onChange={(e) => updateOther(key, Number(e.target.value))}
+                            onChange={(e) =>
+                              updateOther(key, Number(e.target.value))
+                            }
                             className="px-3 py-2 rounded-xl border border-white/15 bg-white/10 text-white focus:outline-none focus:ring-2 focus:ring-white/30"
                           />
                         </div>
@@ -527,7 +604,9 @@ export default function Page() {
                     }
                     return (
                       <div key={key} className="flex flex-col">
-                        <label className="text-sm text-white/80 mb-1">{key}</label>
+                        <label className="text-sm text-white/80 mb-1">
+                          {key}
+                        </label>
                         <textarea
                           rows={4}
                           value={val ?? ''}
@@ -546,7 +625,10 @@ export default function Page() {
             <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <div className="text-white/90 font-medium">
-                  Fotografije {(draft.fotografije?.length ?? 0) > 0 ? `(${draft.fotografije?.length})` : ''}
+                  Fotografije{' '}
+                  {(draft.fotografije?.length ?? 0) > 0
+                    ? `(${draft.fotografije?.length})`
+                    : ''}
                 </div>
                 <div className="flex gap-2">
                   <label className="px-3 py-2 rounded-xl border border-white/20 bg-white/5 hover:bg-white/10 cursor-pointer">
@@ -571,7 +653,9 @@ export default function Page() {
               </div>
 
               {(!draft.fotografije || draft.fotografije.length === 0) && (
-                <div className="text-white/60 text-sm">Nema priloženih fotografija.</div>
+                <div className="text-white/60 text-sm">
+                  Nema priloženih fotografija.
+                </div>
               )}
 
               {draft.fotografije && draft.fotografije.length > 0 && (
@@ -604,7 +688,10 @@ export default function Page() {
 
             {/* Actions */}
             <div className="flex gap-2 justify-end">
-              <button onClick={closeEdit} className="px-4 py-2 rounded-xl border border-white/20 bg-white/5 hover:bg-white/10">
+              <button
+                onClick={closeEdit}
+                className="px-4 py-2 rounded-xl border border-white/20 bg-white/5 hover:bg-white/10"
+              >
                 Otkaži
               </button>
               <button

--- a/src/app/(tabs)/unos/page.tsx
+++ b/src/app/(tabs)/unos/page.tsx
@@ -25,21 +25,21 @@ export default function UnosPage() {
     setPickedCount(0);
   }
 
- async function makePhotoItem(file: File): Promise<PhotoItem> {
-  const compressed = await compressImage(file);        // Blob
-  const blobUrl    = await fileToBlobUrl(compressed);  // 'blob:' za UI
-  const data       = await blobToBase64(compressed);   // base64 za export i trajni prikaz
+  async function makePhotoItem(file: File): Promise<PhotoItem> {
+    const compressed = await compressImage(file); // Blob
+    const blobUrl = await fileToBlobUrl(compressed); // 'blob:' za UI
+    const data = await blobToBase64(compressed); // base64 za export i trajni prikaz
 
-  return {
-    id: uuid(),
-    fileName: file.name || 'photo.jpg',
-    data,                 // 1) trajno – Excel i pregled
-    blobUrl,              // 2) trenutno – pregled prije snimanja
-    url: blobUrl,         // 3) legacy kompatibilnost (UI koji čita .url)
-    mimeType: compressed.type,
-    blob: compressed,     // (opciono – ako već čuvaš Blob u IndexedDB)
-  };
-}
+    return {
+      id: uuid(),
+      fileName: file.name || 'photo.jpg',
+      data, // 1) trajno – Excel i pregled
+      blobUrl, // 2) trenutno – pregled prije snimanja
+      url: blobUrl, // 3) legacy kompatibilnost (UI koji čita .url)
+      mimeType: compressed.type,
+      blob: compressed, // (opciono – ako već čuvaš Blob u IndexedDB)
+    };
+  }
 
   async function onSubmit(form: HTMLFormElement) {
     try {
@@ -49,7 +49,8 @@ export default function UnosPage() {
       const fd = new FormData(form);
 
       // Datumski input već vraća "YYYY-MM-DD" — tako i snimamo
-      const datum = (fd.get('datum') as string) || new Date().toISOString().slice(0, 10);
+      const datum =
+        (fd.get('datum') as string) || new Date().toISOString().slice(0, 10);
       const kupac = (fd.get('kupac') as string)?.trim();
       const vrstaKontakta = fd.get('vrstaKontakta') as ContactType;
 
@@ -60,8 +61,10 @@ export default function UnosPage() {
 
       // Skupi sve fajlove iz oba inputa
       const files: File[] = [];
-      if (camInputRef.current?.files) files.push(...Array.from(camInputRef.current.files));
-      if (fileInputRef.current?.files) files.push(...Array.from(fileInputRef.current.files));
+      if (camInputRef.current?.files)
+        files.push(...Array.from(camInputRef.current.files));
+      if (fileInputRef.current?.files)
+        files.push(...Array.from(fileInputRef.current.files));
 
       if (files.length > 10) {
         alert('Maksimalno 10 slika po aktivnosti.');
@@ -105,7 +108,10 @@ export default function UnosPage() {
   return (
     <form
       className="grid gap-3"
-      onSubmit={(e) => { e.preventDefault(); onSubmit(e.currentTarget); }}
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(e.currentTarget);
+      }}
     >
       <div className="grid gap-1">
         <label>Datum*</label>
@@ -120,17 +126,30 @@ export default function UnosPage() {
 
       <div className="grid gap-1">
         <label>Kupac*</label>
-        <input name="kupac" required className="bg-neutral-900 rounded px-3 py-2" placeholder="Naziv kupca" />
+        <input
+          name="kupac"
+          required
+          className="bg-neutral-900 rounded px-3 py-2"
+          placeholder="Naziv kupca"
+        />
       </div>
 
       <div className="grid gap-1">
         <label>Lokacija</label>
-        <input name="lokacija" className="bg-neutral-900 rounded px-3 py-2" placeholder="npr. Sarajevo" />
+        <input
+          name="lokacija"
+          className="bg-neutral-900 rounded px-3 py-2"
+          placeholder="npr. Sarajevo"
+        />
       </div>
 
       <div className="grid gap-1">
         <label>Vrsta kontakta*</label>
-        <select name="vrstaKontakta" required className="bg-neutral-900 rounded px-3 py-2">
+        <select
+          name="vrstaKontakta"
+          required
+          className="bg-neutral-900 rounded px-3 py-2"
+        >
           <option value="fizicki">Fizički</option>
           <option value="telefon">Telefonski</option>
           <option value="email">Email</option>
@@ -141,17 +160,30 @@ export default function UnosPage() {
 
       <div className="grid gap-1">
         <label>Tema (kratko)</label>
-        <textarea name="tema" maxLength={500} className="bg-neutral-900 rounded px-3 py-2" rows={2} />
+        <textarea
+          name="tema"
+          maxLength={500}
+          className="bg-neutral-900 rounded px-3 py-2"
+          rows={2}
+        />
       </div>
 
       <div className="grid gap-1">
         <label>Zaključak</label>
-        <textarea name="zakljucak" className="bg-neutral-900 rounded px-3 py-2" rows={2} />
+        <textarea
+          name="zakljucak"
+          className="bg-neutral-900 rounded px-3 py-2"
+          rows={2}
+        />
       </div>
 
       <div className="grid gap-1">
         <label>Sljedeći korak</label>
-        <textarea name="sljedeciKorak" className="bg-neutral-900 rounded px-3 py-2" rows={2} />
+        <textarea
+          name="sljedeciKorak"
+          className="bg-neutral-900 rounded px-3 py-2"
+          rows={2}
+        />
       </div>
 
       <div className="flex items-center gap-2">
@@ -161,7 +193,11 @@ export default function UnosPage() {
 
       <div className="grid gap-1">
         <label>Konkurencija</label>
-        <textarea name="konkurencija" className="bg-neutral-900 rounded px-3 py-2" rows={2} />
+        <textarea
+          name="konkurencija"
+          className="bg-neutral-900 rounded px-3 py-2"
+          rows={2}
+        />
       </div>
 
       {/* FOTO sekcija */}
@@ -206,11 +242,19 @@ export default function UnosPage() {
 
       <div className="grid gap-1">
         <label>Napomena</label>
-        <textarea name="napomena" className="bg-neutral-900 rounded px-3 py-2" rows={2} />
+        <textarea
+          name="napomena"
+          className="bg-neutral-900 rounded px-3 py-2"
+          rows={2}
+        />
       </div>
 
       <div className="flex gap-2">
-        <button disabled={saving} className="bg-sky-600 hover:bg-sky-500 rounded px-4 py-2" type="submit">
+        <button
+          disabled={saving}
+          className="bg-sky-600 hover:bg-sky-500 rounded px-4 py-2"
+          type="submit"
+        >
           {saving ? 'Snima…' : 'Sačuvaj'}
         </button>
         <button
@@ -228,7 +272,9 @@ export default function UnosPage() {
         </button>
       </div>
 
-      <p className="text-xs opacity-70">* obavezna polja: Datum, Kupac, Vrsta kontakta</p>
+      <p className="text-xs opacity-70">
+        * obavezna polja: Datum, Kupac, Vrsta kontakta
+      </p>
     </form>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,9 @@
-﻿@import "tailwindcss";
+﻿@import 'tailwindcss';
 
-:root { color-scheme: dark; }
-html, body { height: 100%; }
+:root {
+  color-scheme: dark;
+}
+html,
+body {
+  height: 100%;
+}

--- a/src/app/install-prompt.tsx
+++ b/src/app/install-prompt.tsx
@@ -10,7 +10,8 @@ export default function InstallPrompt() {
   useEffect(() => {
     // Ako je već instalirano (standalone), ne nudimo ništa
     const isStandalone =
-      (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) ||
+      (window.matchMedia &&
+        window.matchMedia('(display-mode: standalone)').matches) ||
       // iOS posebni flag
       (navigator as any).standalone === true;
 
@@ -22,7 +23,9 @@ export default function InstallPrompt() {
     // iOS detekcija (bez MSStream): UA + iPadOS (MacIntel + touch)
     const ua = navigator.userAgent || '';
     const isIOSUA = /iPad|iPhone|iPod/.test(ua);
-    const isIPadOS = navigator.platform === 'MacIntel' && (navigator as any).maxTouchPoints > 1;
+    const isIPadOS =
+      navigator.platform === 'MacIntel' &&
+      (navigator as any).maxTouchPoints > 1;
     const isIOS = isIOSUA || isIPadOS;
 
     if (isIOS) {
@@ -62,7 +65,9 @@ export default function InstallPrompt() {
         type="button"
         className="px-3 py-1 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm"
         onClick={() =>
-          alert('Na iPhone/iPad instalacija ide iz Safari-ja: Share → Add to Home Screen.')
+          alert(
+            'Na iPhone/iPad instalacija ide iz Safari-ja: Share → Add to Home Screen.',
+          )
         }
       >
         Dodaj na početni ekran
@@ -76,7 +81,9 @@ export default function InstallPrompt() {
         type="button"
         className="px-3 py-1 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm"
         onClick={() =>
-          alert('U Chrome/Edge otvori meni (⋮) → Install app / Add to Home screen.')
+          alert(
+            'U Chrome/Edge otvori meni (⋮) → Install app / Add to Home screen.',
+          )
         }
       >
         Instaliraj (upute)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,6 @@ import InstallPrompt from './install-prompt';
 import SWRegister from './sw-register';
 import Script from 'next/script';
 
-
-
 // ⬅️ OVO MORA POSTOJATI:
 import './globals.css';
 
@@ -22,7 +20,11 @@ export const metadata: Metadata = {
     ],
     apple: '/icons/icon-192.png',
   },
-  appleWebApp: { capable: true, statusBarStyle: 'black-translucent', title: 'Mini KPI' },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'black-translucent',
+    title: 'Mini KPI',
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
@@ -40,14 +42,15 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <Link href="/pregled">Pregled</Link>
             <Link href="/izvjestaj">Izvještaj</Link>
             <Link href="/period">Periodični</Link>
-            <div className="ml-auto"><InstallPrompt /></div>
+            <div className="ml-auto">
+              <InstallPrompt />
+            </div>
           </nav>
         </header>
         <main className="mx-auto max-w-3xl p-4">{children}</main>
-
         <SWRegister /> {/* ⬅️ ručna registracija SW */}
         <Script id="sw-register" strategy="afterInteractive">
-{`
+          {`
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker.getRegistration().then((reg) => {
@@ -63,8 +66,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     });
   }
 `}
-</Script>
-
+        </Script>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,3 @@
-export default function Page() { return <h1>KPI Početna</h1>; }
+export default function Page() {
+  return <h1>KPI Početna</h1>;
+}

--- a/src/app/pwa-register.tsx
+++ b/src/app/pwa-register.tsx
@@ -34,9 +34,11 @@ export default function PWARegister() {
   if (!updated) return null;
 
   return (
-    <div className="fixed bottom-3 left-1/2 -translate-x-1/2 z-50
+    <div
+      className="fixed bottom-3 left-1/2 -translate-x-1/2 z-50
                     bg-white/10 backdrop-blur border border-white/20
-                    text-white px-3 py-2 rounded-xl flex gap-2 items-center">
+                    text-white px-3 py-2 rounded-xl flex gap-2 items-center"
+    >
       <span>Aplikacija je ažurirana.</span>
       <button
         className="px-2 py-1 rounded-lg bg-blue-600 hover:bg-blue-500"

--- a/src/app/theme-color.tsx
+++ b/src/app/theme-color.tsx
@@ -4,10 +4,15 @@ import { useEffect } from 'react';
 export default function ThemeColor({
   light = '#0b5ed7',
   dark = '#0b5ed7',
-}: { light?: string; dark?: string }) {
+}: {
+  light?: string;
+  dark?: string;
+}) {
   useEffect(() => {
     // osnovni <meta name="theme-color">
-    let base = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+    let base = document.querySelector<HTMLMetaElement>(
+      'meta[name="theme-color"]',
+    );
     if (!base) {
       base = document.createElement('meta');
       base.name = 'theme-color';
@@ -17,7 +22,9 @@ export default function ThemeColor({
 
     // varijante za light/dark
     const ensure = (media: string, content: string) => {
-      let el = document.querySelector<HTMLMetaElement>(`meta[name="theme-color"][media="${media}"]`);
+      let el = document.querySelector<HTMLMetaElement>(
+        `meta[name="theme-color"][media="${media}"]`,
+      );
       if (!el) {
         el = document.createElement('meta');
         el.name = 'theme-color';

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -20,7 +20,8 @@ export class MiniKpiDB extends Dexie {
       // Primarni ključ: id
       // Sekundarni indeksi: datum, kupac, vrstaKontakta, createdAt, updatedAt
       // Dodan i složeni indeks [datum+kupac] (može pomoći kod izvještaja po kupcu)
-      activities: 'id, datum, kupac, vrstaKontakta, createdAt, updatedAt, [datum+kupac]'
+      activities:
+        'id, datum, kupac, vrstaKontakta, createdAt, updatedAt, [datum+kupac]',
     });
 
     // (opciono) automatski open — Dexie sam otvara pri prvom pristupu,
@@ -51,7 +52,7 @@ export async function addActivity(a: ActivityItem) {
     id: a.id, // očekuješ da je već postavljen (npr. uuid)
     datum: normalizeDate(a.datum),
     createdAt: a.createdAt || now,
-    updatedAt: now
+    updatedAt: now,
   };
 
   const pk = await db.activities.add(rec);
@@ -64,12 +65,14 @@ export async function updateActivity(id: string, patch: Partial<ActivityItem>) {
   const payload: Partial<ActivityItem> = {
     ...patch,
     ...(patch.datum ? { datum: normalizeDate(patch.datum) } : {}),
-    updatedAt: new Date().toISOString()
+    updatedAt: new Date().toISOString(),
   };
 
   const changed = await db.activities.update(id, payload);
   if (changed === 0) {
-    throw new Error(`updateActivity: zapis sa id="${id}" ne postoji ili nije promijenjen.`);
+    throw new Error(
+      `updateActivity: zapis sa id="${id}" ne postoji ili nije promijenjen.`,
+    );
   }
   return changed; // broj promijenjenih zapisa (0 ili 1)
 }
@@ -90,7 +93,10 @@ export async function getActivitiesByPeriod(from: string, to: string) {
   const a = normalizeDate(from);
   const b = normalizeDate(to);
   const [lo, hi] = a <= b ? [a, b] : [b, a];
-  return db.activities.where('datum').between(lo, hi, true, true).sortBy('datum');
+  return db.activities
+    .where('datum')
+    .between(lo, hi, true, true)
+    .sortBy('datum');
 }
 
 /** (opciono) Brisanje svega — pažljivo koristiti */

--- a/src/lib/excel.ts
+++ b/src/lib/excel.ts
@@ -7,12 +7,24 @@ type ExportMode =
   | { kind: 'period'; from: string; to: string };
 
 const COLS = [
-  'Datum','Kupac','Lokacija','Vrsta kontakta','Tema','Zaključak',
-  'Sljedeći korak','CRM ažuriran','Konkurencija','Napomena','Fotografije'
+  'Datum',
+  'Kupac',
+  'Lokacija',
+  'Vrsta kontakta',
+  'Tema',
+  'Zaključak',
+  'Sljedeći korak',
+  'CRM ažuriran',
+  'Konkurencija',
+  'Napomena',
+  'Fotografije',
 ] as const;
 
 // --- Helpers ---
-function base64ToArrayBuffer(dataUrl: string): { buf: ArrayBuffer; ext: 'png'|'jpeg' } {
+function base64ToArrayBuffer(dataUrl: string): {
+  buf: ArrayBuffer;
+  ext: 'png' | 'jpeg';
+} {
   const [head, b64] = dataUrl.split(',');
   if (!b64) throw new Error('Bad data URL');
   const isPng = head?.includes('image/png');
@@ -22,16 +34,25 @@ function base64ToArrayBuffer(dataUrl: string): { buf: ArrayBuffer; ext: 'png'|'j
   return { buf: bytes.buffer, ext: isPng ? 'png' : 'jpeg' };
 }
 
-function guessExtByNameOrMime(fileName?: string, mime?: string): 'png'|'jpeg' {
+function guessExtByNameOrMime(
+  fileName?: string,
+  mime?: string,
+): 'png' | 'jpeg' {
   const n = (fileName || '').toLowerCase();
   if (n.endsWith('.png') || mime === 'image/png') return 'png';
   return 'jpeg';
 }
 
 // POKRIVA: p.data (base64), p.blob (Blob), p.blobUrl (blob:), p.url (legacy)
-async function getImageBuffer(p: any): Promise<{ buf: ArrayBuffer; ext: 'png'|'jpeg' } | null> {
+async function getImageBuffer(
+  p: any,
+): Promise<{ buf: ArrayBuffer; ext: 'png' | 'jpeg' } | null> {
   try {
-    if (p?.data && typeof p.data === 'string' && p.data.startsWith('data:image/')) {
+    if (
+      p?.data &&
+      typeof p.data === 'string' &&
+      p.data.startsWith('data:image/')
+    ) {
       return base64ToArrayBuffer(p.data);
     }
     if (p?.blob instanceof Blob) {
@@ -53,57 +74,98 @@ async function getImageBuffer(p: any): Promise<{ buf: ArrayBuffer; ext: 'png'|'j
   }
 }
 
-export async function exportActivitiesToExcel(rows: ActivityItem[], mode: ExportMode) {
+export async function exportActivitiesToExcel(
+  rows: ActivityItem[],
+  mode: ExportMode,
+) {
   const wb = new ExcelJS.Workbook();
-  const ws = wb.addWorksheet('KPI', { views: [{ state: 'frozen', ySplit: 1 }] });
+  const ws = wb.addWorksheet('KPI', {
+    views: [{ state: 'frozen', ySplit: 1 }],
+  });
   ws.properties.defaultRowHeight = 22;
 
   const COLS = [
-    'Datum','Kupac','Lokacija','Vrsta kontakta','Tema','Zaključak',
-    'Sljedeći korak','CRM ažuriran','Konkurencija','Napomena','Fotografije'
+    'Datum',
+    'Kupac',
+    'Lokacija',
+    'Vrsta kontakta',
+    'Tema',
+    'Zaključak',
+    'Sljedeći korak',
+    'CRM ažuriran',
+    'Konkurencija',
+    'Napomena',
+    'Fotografije',
   ] as const;
 
-  ws.columns = (COLS as readonly string[]).map(h => ({
-    header: h, key: h, width: h === 'Fotografije' ? 32 : 22
+  ws.columns = (COLS as readonly string[]).map((h) => ({
+    header: h,
+    key: h,
+    width: h === 'Fotografije' ? 32 : 22,
   }));
   ws.getRow(1).font = { bold: true };
-  ws.autoFilter = { from: { row: 1, column: 1 }, to: { row: 1, column: COLS.length } };
-  ws.pageSetup = { paperSize: 9, fitToPage: true, fitToWidth: 1, fitToHeight: 0, orientation: 'landscape' };
+  ws.autoFilter = {
+    from: { row: 1, column: 1 },
+    to: { row: 1, column: COLS.length },
+  };
+  ws.pageSetup = {
+    paperSize: 9,
+    fitToPage: true,
+    fitToWidth: 1,
+    fitToHeight: 0,
+    orientation: 'landscape',
+  };
 
   // Header i poravnanje + wrap
   ws.getRow(1).eachCell((cell) => {
-    cell.alignment = { horizontal: 'center', vertical: 'middle', wrapText: true };
+    cell.alignment = {
+      horizontal: 'center',
+      vertical: 'middle',
+      wrapText: true,
+    };
   });
   for (let c = 1; c <= COLS.length; c++) {
     const name = COLS[c - 1];
     const col = ws.getColumn(c);
-    if (name === 'CRM ažuriran') col.alignment = { horizontal: 'center', vertical: 'middle' };
-    else if (name === 'Fotografije') col.alignment = { horizontal: 'left', vertical: 'top' };
+    if (name === 'CRM ažuriran')
+      col.alignment = { horizontal: 'center', vertical: 'middle' };
+    else if (name === 'Fotografije')
+      col.alignment = { horizontal: 'left', vertical: 'top' };
     else col.alignment = { wrapText: true, vertical: 'top' };
   }
 
   // ---- Helpers za mjere/konverzije ----
   const pxToPt = (px: number) => px * 0.75; // 96dpi -> points
-  const colWidthToPixels = (wChars: number) => Math.floor(((256 * wChars + Math.floor(128 / 7)) / 256) * 7);
+  const colWidthToPixels = (wChars: number) =>
+    Math.floor(((256 * wChars + Math.floor(128 / 7)) / 256) * 7);
   const pixelsToColWidth = (px: number) =>
-    Math.min(255, Math.round((((px / 7) * 256 - Math.floor(128 / 7)) / 256) * 100) / 100); // cap Excel max 255
+    Math.min(
+      255,
+      Math.round((((px / 7) * 256 - Math.floor(128 / 7)) / 256) * 100) / 100,
+    ); // cap Excel max 255
 
   // Dimenzije i razmaci za slike (px)
-  const IMG_W = 96;   // širina jedne slike
-  const IMG_H = 72;   // visina jedne slike
-  const GAP_X = 6;    // razmak između slika
-  const PAD_X = 6;    // unutrašnji lijevi/desni "padding" u ćeliji
+  const IMG_W = 96; // širina jedne slike
+  const IMG_H = 72; // visina jedne slike
+  const GAP_X = 6; // razmak između slika
+  const PAD_X = 6; // unutrašnji lijevi/desni "padding" u ćeliji
   const TOP_FRAC = 0.1; // mali gornji offset unutar reda (u visinama reda)
 
   // Širina kolone "Fotografije" = dovoljno za NAJVEĆI broj slika u bilo kom redu
-  const maxPhotos = rows.reduce((m, a) => Math.max(m, ((a as any).fotografije?.length ?? 0)), 0);
+  const maxPhotos = rows.reduce(
+    (m, a) => Math.max(m, (a as any).fotografije?.length ?? 0),
+    0,
+  );
   if (maxPhotos > 0) {
     const totalPx = PAD_X + maxPhotos * IMG_W + (maxPhotos - 1) * GAP_X + PAD_X; // lijevi+desni pad + sve slike + razmaci
     ws.getColumn(COLS.length).width = pixelsToColWidth(totalPx);
   }
 
   // ---- Helpers za dohvat binara slike (robustan) ----
-  function base64ToArrayBuffer(dataUrl: string): { buf: ArrayBuffer; ext: 'png'|'jpeg' } {
+  function base64ToArrayBuffer(dataUrl: string): {
+    buf: ArrayBuffer;
+    ext: 'png' | 'jpeg';
+  } {
     const [head, b64] = dataUrl.split(',');
     const isPng = head?.includes('image/png');
     const bin = atob(b64);
@@ -111,16 +173,28 @@ export async function exportActivitiesToExcel(rows: ActivityItem[], mode: Export
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
     return { buf: bytes.buffer, ext: isPng ? 'png' : 'jpeg' };
   }
-  function guessExtByNameOrMime(fileName?: string, mime?: string): 'png'|'jpeg' {
+  function guessExtByNameOrMime(
+    fileName?: string,
+    mime?: string,
+  ): 'png' | 'jpeg' {
     const n = (fileName || '').toLowerCase();
     if (n.endsWith('.png') || mime === 'image/png') return 'png';
     return 'jpeg';
   }
-  async function getImageBuffer(p: any): Promise<{ buf: ArrayBuffer; ext: 'png'|'jpeg' } | null> {
+  async function getImageBuffer(
+    p: any,
+  ): Promise<{ buf: ArrayBuffer; ext: 'png' | 'jpeg' } | null> {
     try {
-      if (p?.data && typeof p.data === 'string' && p.data.startsWith('data:image/')) return base64ToArrayBuffer(p.data);
+      if (
+        p?.data &&
+        typeof p.data === 'string' &&
+        p.data.startsWith('data:image/')
+      )
+        return base64ToArrayBuffer(p.data);
       if (p?.base64 && typeof p.base64 === 'string') {
-        const url = p.base64.startsWith('data:') ? p.base64 : `data:image/jpeg;base64,${p.base64}`;
+        const url = p.base64.startsWith('data:')
+          ? p.base64
+          : `data:image/jpeg;base64,${p.base64}`;
         return base64ToArrayBuffer(url);
       }
       if (p?.blob instanceof Blob) {
@@ -153,7 +227,7 @@ export async function exportActivitiesToExcel(rows: ActivityItem[], mode: Export
       a.crmAzuriran ? 'DA' : 'NE',
       a.konkurencija ?? '',
       a.napomena ?? '',
-      '' // placeholder za slike
+      '', // placeholder za slike
     ]);
 
     const rowIndex = r.number;
@@ -162,7 +236,10 @@ export async function exportActivitiesToExcel(rows: ActivityItem[], mode: Export
 
     if (photos.length > 0) {
       // visina reda = visina slike (+mali padding)
-      ws.getRow(rowIndex).height = Math.max(ws.getRow(rowIndex).height ?? 0, Math.ceil(pxToPt(IMG_H + 6)));
+      ws.getRow(rowIndex).height = Math.max(
+        ws.getRow(rowIndex).height ?? 0,
+        Math.ceil(pxToPt(IMG_H + 6)),
+      );
 
       // kolona širina u px (već postavljena gore na maxPhotos)
       const colPx = colWidthToPixels(Number(ws.getColumn(imgCol).width ?? 32));
@@ -180,7 +257,7 @@ export async function exportActivitiesToExcel(rows: ActivityItem[], mode: Export
 
         ws.addImage(imgId, {
           tl: { col: imgCol - 1 + xFrac, row: rowIndex - 1 + yFrac },
-          ext: { width: IMG_W, height: IMG_H }
+          ext: { width: IMG_W, height: IMG_H },
         });
       }
     }
@@ -192,7 +269,9 @@ export async function exportActivitiesToExcel(rows: ActivityItem[], mode: Export
       : `KPI_IZVJESTAJ_${mode.from}_do_${mode.to}.xlsx`;
 
   const buf = await wb.xlsx.writeBuffer();
-  const blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+  const blob = new Blob([buf], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
   const url = URL.createObjectURL(blob);
   const aEl = document.createElement('a');
   aEl.href = url;

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -32,7 +32,7 @@ export async function fileToBlobUrl(input: File | Blob): Promise<string> {
  */
 export async function compressImage(
   input: File | Blob,
-  options: { maxDim?: number; quality?: number } = {}
+  options: { maxDim?: number; quality?: number } = {},
 ): Promise<Blob> {
   const { maxDim = 1600, quality = 0.8 } = options;
 
@@ -49,7 +49,10 @@ export async function compressImage(
     const isPng = mime.includes('png');
 
     // Bez skaliranja i već dobar tip => nema recompress
-    if (scale === 1 && (mime.includes('jpeg') || mime.includes('jpg') || mime.includes('png'))) {
+    if (
+      scale === 1 &&
+      (mime.includes('jpeg') || mime.includes('jpg') || mime.includes('png'))
+    ) {
       return srcBlob;
     }
 
@@ -65,9 +68,9 @@ export async function compressImage(
 
     const outBlob: Blob = await new Promise((resolve, reject) => {
       canvas.toBlob(
-        b => (b ? resolve(b) : reject(new Error('toBlob failed'))),
+        (b) => (b ? resolve(b) : reject(new Error('toBlob failed'))),
         outMime,
-        isPng ? undefined : quality
+        isPng ? undefined : quality,
       );
     });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,18 +6,18 @@ export interface PhotoItem {
   id: string;
   fileName?: string;
   // trajni sadržaj
-  data?: string;             // data:image/*;base64,...
+  data?: string; // data:image/*;base64,...
   // za UI (kratkoživuće)
-  blobUrl?: string;          // novi naziv
-  url?: string;              // legacy naziv - ostavljamo radi kompatibilnosti
+  blobUrl?: string; // novi naziv
+  url?: string; // legacy naziv - ostavljamo radi kompatibilnosti
   // opcionalno binarno iz IndexedDB
-  blob?: Blob;               // legacy binarno polje
+  blob?: Blob; // legacy binarno polje
   mimeType?: string;
 }
 
 export interface ActivityItem {
-  id: string;                 // uuid
-  datum: string;              // "YYYY-MM-DD" ili ISO; upiti su robusni
+  id: string; // uuid
+  datum: string; // "YYYY-MM-DD" ili ISO; upiti su robusni
   kupac: string;
   lokacija?: string | null;
   vrstaKontakta: ContactType;
@@ -27,7 +27,7 @@ export interface ActivityItem {
   crmAzuriran: boolean;
   konkurencija?: string | null;
   napomena?: string | null;
-  fotografije?: PhotoItem[];  // <= ovdje je PhotoItem sa .data (base64)
+  fotografije?: PhotoItem[]; // <= ovdje je PhotoItem sa .data (base64)
   createdAt?: string;
   updatedAt?: string;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,1 +1,1 @@
-@import "tailwindcss";
+@import 'tailwindcss';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["src/*"]
     },
     "strict": false,
     "jsx": "preserve",
@@ -15,11 +13,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "allowJs": true,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,
     "incremental": true,
     "plugins": [
@@ -28,13 +22,6 @@
       }
     ]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- install eslint and prettier tooling with Next.js rules
- add project-wide formatting preferences
- format existing source files

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find the config "next/core-web-vitals" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68b18cabf7bc83339f5eb9568c824495